### PR TITLE
don't import host environment variables

### DIFF
--- a/lxc.py
+++ b/lxc.py
@@ -45,6 +45,7 @@ class Connection(object):
         vvv("EXEC %s" % (local_cmd), host=self.host)
 
         pid = self.container.attach(_lxc.attach_run_command, local_cmd,
+                env_policy=_lxc.LXC_ATTACH_CLEAR_ENV,
                 stdout=write_stdout,
                 stderr=write_stderr)
 


### PR DESCRIPTION
  This might cause issues with systems where hosts variables
  conflicts with guest environment (archlinux PATH doesn't contains
  /bin whereas debian does)
